### PR TITLE
Added dependency to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Compiling
 
 Requires Python 2 and gcc installation.
 
+Make sure you have a development version of freeglut installed
+E.g.: `sudo apt install freeglut3-dev`.
+
 ```
 pip install pillow
 pip install pyglet


### PR DESCRIPTION
This fixes the following error when trying to run the python code:

ImportError: Library "GLU" not found.